### PR TITLE
Style: 스타일 조정 및 서브타이틀 추가

### DIFF
--- a/frontend/src/components/pages/Curation/Curation.styled.js
+++ b/frontend/src/components/pages/Curation/Curation.styled.js
@@ -151,7 +151,8 @@ export const HashTag = styled.a`
 
 export const SubTitle = styled.p`
     font-size: 14px;
-    font-weight: 400;
+    font-weight: 200;
     text-align: center;
+    margin-top: 5px;
     margin-bottom: 20px;
 `;

--- a/frontend/src/components/pages/Curation/Curation.styled.js
+++ b/frontend/src/components/pages/Curation/Curation.styled.js
@@ -148,3 +148,10 @@ export const HashTag = styled.a`
         opacity: 0.6;
     }
 `;
+
+export const SubTitle = styled.p`
+    font-size: 14px;
+    font-weight: 400;
+    text-align: center;
+    margin-bottom: 20px;
+`;

--- a/frontend/src/components/pages/Curation/components/Slide.jsx
+++ b/frontend/src/components/pages/Curation/components/Slide.jsx
@@ -1,4 +1,9 @@
-import { CommentBox, CurationDataWrapper, Title } from '../Curation.styled';
+import {
+    CommentBox,
+    CurationDataWrapper,
+    SubTitle,
+    Title,
+} from '../Curation.styled';
 import CurationData from '../CurationData';
 
 import React, { useEffect, useState } from 'react';
@@ -159,7 +164,10 @@ const Slide = ({ date, id, setVisibleIndex, visibleIndex, length }) => {
             </Title>
             <Warn recommendData={recommend} />
 
-            <Title>내 아이 맞춤식품</Title>
+            <Title style={{ marginBottom: 0, lineHeight: 1.5 }}>
+                내 아이 맞춤식품
+            </Title>
+            <SubTitle>식재료를 터치해보세요</SubTitle>
             <CurationDataWrapper rows={recommend?.data.length / 2}>
                 {recommend?.data.map((item, index) => (
                     <CurationData
@@ -173,16 +181,18 @@ const Slide = ({ date, id, setVisibleIndex, visibleIndex, length }) => {
 
             <CommentBox>{recommend?.comment}</CommentBox>
 
+            <Title style={{ marginTop: 40, marginBottom: 0, lineHeight: 1.5 }}>
+                편리하게 준비해요
+            </Title>
+            <SubTitle>식재료를 터치해보세요</SubTitle>
             <div
                 style={{
-                    marginTop: 25,
                     marginBottom: 30,
                     display: 'flex',
                     width: '90%',
                     flexWrap: 'wrap',
                 }}
             >
-                <Title>편리하게 준비해요</Title>
                 {recommend?.hashtag?.split('#').map((tag, index) =>
                     tag === '' ? null : (
                         <HashTag
@@ -204,6 +214,7 @@ const Slide = ({ date, id, setVisibleIndex, visibleIndex, length }) => {
                     display: 'flex',
                     alignItems: 'center',
                     flexDirection: 'column',
+                    marginTop: 40,
                 }}
             >
                 <p

--- a/frontend/src/components/pages/QuestionDetail/QuestionDetail.jsx
+++ b/frontend/src/components/pages/QuestionDetail/QuestionDetail.jsx
@@ -36,6 +36,7 @@ const QuestionDetail = () => {
     const [loading, setLoading] = useState(false);
     const [comment, setComment] = useState('');
     const [isPosted, setIsPosted] = useState(false);
+    const [date, setDate] = useState(null);
     const navigate = useNavigate();
     const param = useParams();
     const token = useSelector((state) => state.auth.token);
@@ -52,6 +53,7 @@ const QuestionDetail = () => {
                 setContent(response.data.question.content);
                 setAnswerData([...response.data.answerList]);
                 setTitle(response.data.question.title);
+                setDate(response.data.question.created_at);
                 setLoading(false);
             })
             .catch(async (err) => {
@@ -213,7 +215,7 @@ const QuestionDetail = () => {
             ) : (
                 <Contents>
                     <DiaryTitle layoutId={'question'}>
-                        <Name>{'Q&A'}</Name>
+                        <Name>{date?.split('T')[0]}</Name>
                     </DiaryTitle>
                     <QuestionBox>
                         <QuestionTitle>

--- a/frontend/src/components/pages/QuestionDetail/QuestionDetail.style.js
+++ b/frontend/src/components/pages/QuestionDetail/QuestionDetail.style.js
@@ -16,6 +16,7 @@ export const QuestionContent = styled.p`
     line-height: 1.5;
     padding-bottom: 30px;
     border-bottom: 1px solid rgba(127, 140, 141, 0.7);
+    white-space: pre-line;
 `;
 
 export const AnswerBox = styled.div`


### PR DESCRIPTION
## 맞춤식품 페이지
1. `Curation.styled.js`에 SubTitle컴포넌트 추가하였습니다. 맞춤식품페이지 서브타이틀에 사용됩니다.
2. 해시태그 Title 컴포넌트가 display grid 박스 안에 있어서 밖으로 꺼냈습니다.
3. `HashTag`컴포넌트 전체를 감싸는 div태그에 marginTop 40으로 수정했습니다.
4. Q&A연결 링크에도 marginTop 40으로 조정하였습니다.

## Q&A페이지
1. Q&A 게시글에 `white-space: pre-line` 추가하여 줄바꿈 적용하였습니다.
2. date상태값 세팅하여 작성일자가 타이틀에 보이도록 하였습니다

@ha-yun 