### PR TITLE
feat: 토큰 리프레시 로직 수정 및 통합

### DIFF
--- a/frontend/src/components/atom/Header/Header.jsx
+++ b/frontend/src/components/atom/Header/Header.jsx
@@ -3,22 +3,14 @@ import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { HeaderBox, Icon } from './Header.style';
 import axios from 'axios';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { authActions } from '../../../store/auth-slice';
-// import New from '../New';
-import handleExpired from '../../../helpers/handleExpired';
-// import Mail from '../New/Mail';
 
 const Header = () => {
     const navigate = useNavigate();
     const dispatch = useDispatch();
     const loc = useLocation();
     const locationArray = loc.pathname.split('/');
-    const token = useSelector((state) => state.auth.token);
-    const [isRead, setIsRead] = useState(false);
-    const [list, setList] = useState(null);
-    const [loading, setLoading] = useState(false);
-    const [isInitial, setIsInitial] = useState(true);
 
     const [backActive, setBackActive] = useState(true);
     const [homeActive, setHomeActive] = useState(true);
@@ -26,13 +18,6 @@ const Header = () => {
         window.sessionStorage.getItem('isLoggedIn')
     );
     const [isOpen, setIsOpen] = useState(false);
-
-    const checkIsRead = (noticeList) => {
-        for (let obj of noticeList) {
-            if (!obj.isRead) return false;
-        }
-        return true;
-    };
 
     // 세션스토리지 isLoggedIn 관리
     useEffect(() => {
@@ -46,34 +31,6 @@ const Header = () => {
             location.reload();
         }
     }, [loc.pathname]);
-
-    // 헤더 공지사항 GET 로직
-    // useEffect(() => {
-    //     axios
-    //         .get('https://www.nuseum.site/api/v1/notice/', {
-    //             headers: {
-    //                 Authorization: `Bearer ${token}`,
-    //             },
-    //         })
-    //         .then((response) => {
-    //             setList(response.data);
-    //         })
-    //         .catch(async (err) => {
-    //             console.log(err);
-    //             if (err.response.status === 401) {
-    //                 const { exp, token } = await handleExpired();
-    //                 dispatch(
-    //                     authActions.login({
-    //                         token: token.data.access,
-    //                         exp,
-    //                     })
-    //                 );
-    //             } else {
-    //                 alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-    //             }
-    //             setLoading(false);
-    //         });
-    // }, [token]);
 
     return (
         <HeaderBox>

--- a/frontend/src/components/molecules/FoodImg/FoodImg.jsx
+++ b/frontend/src/components/molecules/FoodImg/FoodImg.jsx
@@ -7,8 +7,6 @@ import { useParams } from 'react-router-dom';
 import useActions from '../../../hooks/useActions';
 import axios from 'axios';
 import { postActions } from '../../../store/meal-slice/post-slice';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
 
 const FoodImg = ({ data, index, isPost, setLoading }) => {
     const dispatch = useDispatch();
@@ -47,20 +45,9 @@ const FoodImg = ({ data, index, isPost, setLoading }) => {
                                     setLoading(false);
                                     alert('이미지가 삭제되었습니다!');
                                 } catch (err) {
-                                    if (err.response.status === 401) {
-                                        const { exp, token } =
-                                            await handleExpired();
-                                        dispatch(
-                                            authActions.login({
-                                                token: token.data.access,
-                                                exp,
-                                            })
-                                        );
-                                    } else {
-                                        alert(
-                                            '오류가 발생했습니다. 담당자에게 문의해주세요!'
-                                        );
-                                    }
+                                    alert(
+                                        '오류가 발생했습니다. 담당자에게 문의해주세요!'
+                                    );
                                     setLoading(false);
                                 }
                             } else {

--- a/frontend/src/components/molecules/ImageCard/ImageCard.jsx
+++ b/frontend/src/components/molecules/ImageCard/ImageCard.jsx
@@ -14,7 +14,6 @@ import useActions from '../../../hooks/useActions';
 import { supplementActions } from '../../../store/supplement-slice';
 import axios from 'axios';
 import { CircularProgress } from '@mui/material';
-import handleExpired from '../../../helpers/handleExpired';
 
 const ImageCard = ({ isSaved, index, data, setFetchedSupplement }) => {
     // index에 접근하여 해당 데이터 수정
@@ -175,19 +174,9 @@ const ImageCard = ({ isSaved, index, data, setFetchedSupplement }) => {
                             alert('영양제 정보가 삭제되었습니다!');
                         } catch (err) {
                             console.log(err);
-                            if (err.response?.status === 401) {
-                                const { exp, token } = await handleExpired();
-                                dispatch(
-                                    authActions.login({
-                                        token: token.data.access,
-                                        exp,
-                                    })
-                                );
-                            } else {
-                                alert(
-                                    '오류가 발생했습니다. 담당자에게 문의해주세요!'
-                                );
-                            }
+                            alert(
+                                '오류가 발생했습니다. 담당자에게 문의해주세요!'
+                            );
                             setLoading(false);
                         }
                     }

--- a/frontend/src/components/molecules/Login/index.jsx
+++ b/frontend/src/components/molecules/Login/index.jsx
@@ -20,25 +20,9 @@ import jwt_decode from 'jwt-decode';
 function Login() {
     const dispatch = useDispatch();
 
-    const [token, setToken] = useState(null);
-
     useEffect(() => {
         window.sessionStorage.removeItem('isLoggedIn');
     }, []);
-    // pwa 설치 관련 코드
-    // const [deferredPrompt, setDeferredPrompt] =
-    //     useRecoilState(deferredPromptState);
-
-    // const installApp = async () => {
-    //     // Show the install prompt
-    //     deferredPrompt.prompt();
-    //     // Wait for the user to respond to the prompt
-    //     const { outcome } = await deferredPrompt.userChoice;
-    //     // Optionally, send analytics event with outcome of user choice
-    //     console.log(`User response to the install prompt: ${outcome}`);
-    //     // We've used the prompt, and can't use it again, throw it away
-    //     setDeferredPrompt(null);
-    // };
 
     const {
         register,
@@ -65,7 +49,7 @@ function Login() {
             dispatch(
                 authActions.login({
                     token: response.data.access_token,
-                    expiration_time: decodedData.exp,
+                    exp: decodedData.exp,
                 })
             );
             window.sessionStorage.setItem('isLoggedIn', true);
@@ -99,7 +83,7 @@ function Login() {
                     dispatch(
                         authActions.login({
                             token: response.data.access_token,
-                            expiration_time: decodedData.exp,
+                            exp: decodedData.exp,
                         })
                     );
                     window.sessionStorage.setItem('isLoggedIn', true);

--- a/frontend/src/components/pages/Analysis/Analysis.jsx
+++ b/frontend/src/components/pages/Analysis/Analysis.jsx
@@ -48,8 +48,6 @@ import {
 import RadarGraph from '../../molecules/RadarGraph';
 import BarGraph from '../../molecules/BarGraph';
 import { useDispatch, useSelector } from 'react-redux';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
 import { useEffect } from 'react';
 
 ChartJS.register(
@@ -187,19 +185,8 @@ const Analysis = () => {
             setNutritionWithoutSupplement(res);
         } catch (err) {
             console.log('ERROR:', err);
-            if (err.response.status === 401) {
-                const { exp, token } = await handleExpired();
-                dispatch(
-                    authActions.login({
-                        token: token.data.access,
-                        exp,
-                    })
-                );
-                setLoading(false);
-            } else {
-                console.log(err);
-                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-            }
+
+            alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
             let initializedNutrition = {
                 energy: 0,
                 protein: 0,
@@ -280,19 +267,7 @@ const Analysis = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                    setLoading(false);
-                } else {
-                    console.log(err);
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 let initializedNutrition = {
                     energy: 0,
                     protein: 0,
@@ -373,18 +348,8 @@ const Analysis = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
-                nu;
+
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
 
                 setLoading(false);
             });
@@ -431,17 +396,8 @@ const Analysis = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
                 let initializedNutrition = {
                     energy: 0,
@@ -517,17 +473,8 @@ const Analysis = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
 
                 let initializedNutrition = {

--- a/frontend/src/components/pages/Curation/Curation.jsx
+++ b/frontend/src/components/pages/Curation/Curation.jsx
@@ -5,8 +5,6 @@ import { Contents } from '../Home/styled';
 import axios from 'axios';
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
 import { useState } from 'react';
 import Slide from './components/Slide';
 import { AnimatePresence, motion } from 'framer-motion';
@@ -31,17 +29,7 @@ const Curation = () => {
             setRecommendList(response.data.reverse());
         } catch (err) {
             console.log(err);
-            if (err.response?.status === 401) {
-                const { exp, token } = await handleExpired();
-                dispatch(
-                    authActions.login({
-                        token: token.data.access,
-                        exp,
-                    })
-                );
-            } else {
-                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-            }
+            alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
         }
     };
 

--- a/frontend/src/components/pages/Curation/components/Slide.jsx
+++ b/frontend/src/components/pages/Curation/components/Slide.jsx
@@ -9,8 +9,6 @@ import CurationData from '../CurationData';
 import React, { useEffect, useState } from 'react';
 import Warn from './Warn';
 import { useDispatch, useSelector } from 'react-redux';
-import { authActions } from '../../../../store/auth-slice';
-import handleExpired from '../../../../helpers/handleExpired';
 import axios from 'axios';
 import BottomSheet from '../../../molecules/BottomSheet';
 import HashTag from './HashTag';
@@ -118,17 +116,8 @@ const Slide = ({ date, id, setVisibleIndex, visibleIndex, length }) => {
         } catch (err) {
             console.log(err);
             if (!id) return;
-            if (err.response.status === 401) {
-                const { exp, token } = await handleExpired();
-                dispatch(
-                    authActions.login({
-                        token: token.data.access,
-                        exp,
-                    })
-                );
-            } else {
-                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-            }
+
+            alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
         }
     };
     useEffect(() => {

--- a/frontend/src/components/pages/Home/index.jsx
+++ b/frontend/src/components/pages/Home/index.jsx
@@ -13,11 +13,6 @@ import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
-import { authActions } from '../../../store/auth-slice';
-import handleExpired from '../../../helpers/handleExpired';
-
-let init = true;
-
 function Home() {
     const isLoggedIn = window.sessionStorage.getItem('isLoggedIn');
 
@@ -28,17 +23,8 @@ function Home() {
             navigate('/login');
             return;
         }
-        fetchTokenInHome();
     }, [dispatch]);
-    const fetchTokenInHome = async () => {
-        const { exp, token } = await handleExpired();
-        dispatch(
-            authActions.login({
-                token: token.data.access,
-                exp,
-            })
-        );
-    };
+
     const menu = [
         [diary, '식단일기', 'diary'],
         [analysis, '식이분석', 'analysis'],

--- a/frontend/src/components/pages/Meal/Meal.jsx
+++ b/frontend/src/components/pages/Meal/Meal.jsx
@@ -15,7 +15,6 @@ import {
     TagBox,
 } from '../Record/styled';
 import { VerticalImageBox } from '../Today/Today.style';
-import { handleExpired } from '../../../helpers/handleExpired';
 import useActions from '../../../hooks/useActions';
 import { useParams } from 'react-router-dom';
 import { useCallback, useEffect, useState } from 'react';
@@ -72,20 +71,7 @@ const Meal = () => {
             .catch(async (err) => {
                 console.log(err);
 
-                // 액세스토큰이 만료되면
-                // 리프레시토큰을 가지고 새로 발급받는다.
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
             });
     };
@@ -103,7 +89,7 @@ const Meal = () => {
         setLoading(true);
 
         fetchData();
-    }, [dispatch, token]);
+    }, [dispatch]);
     // 액션 훅 호출
     const action = useActions(param.when);
 
@@ -152,9 +138,11 @@ const Meal = () => {
             setPage((prev) => prev + 1);
             setHasNextPage(response.data.next ? true : false);
             setIsFetching(false);
-        } catch (error) {
-            // handleExpired 로직 추가 필요
-            console.log(error);
+        } catch (err) {
+            console.log(err);
+
+            alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
+            setLoading(false);
         }
     }, [page, searchParam]);
 
@@ -256,17 +244,7 @@ const Meal = () => {
                 }
             })
             .catch(async (err) => {
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
             });
 
         setSearchParam(foodName);
@@ -341,21 +319,10 @@ const Meal = () => {
                                               setLoading(false);
                                           } catch (err) {
                                               console.log(err);
-                                              if (err.response.status === 401) {
-                                                  const { exp, token } =
-                                                      handleExpired();
 
-                                                  dispatch(
-                                                      authActions.login({
-                                                          token,
-                                                          exp,
-                                                      })
-                                                  );
-                                              } else {
-                                                  alert(
-                                                      '오류가 발생했습니다. 담당자에게 문의해주세요!'
-                                                  );
-                                              }
+                                              alert(
+                                                  '오류가 발생했습니다. 담당자에게 문의해주세요!'
+                                              );
                                               setIsLoading(false);
                                           }
                                       }
@@ -419,7 +386,14 @@ const Meal = () => {
                 // 음식데이터 저장버튼
                 <button
                     onClick={() => savePost()}
-                    style={{ marginBottom: '30px', background: '#8A8A8E', border:'none', borderRadius: '20px', padding: '5px 35px', color: 'white' }}
+                    style={{
+                        marginBottom: '30px',
+                        background: '#8A8A8E',
+                        border: 'none',
+                        borderRadius: '20px',
+                        padding: '5px 35px',
+                        color: 'white',
+                    }}
                 >
                     저장
                 </button>

--- a/frontend/src/components/pages/My/My.jsx
+++ b/frontend/src/components/pages/My/My.jsx
@@ -9,10 +9,7 @@ pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/$
 import prev from '../../../assets/prev.png';
 import next from '../../../assets/next.png';
 import { Page, Document } from 'react-pdf';
-
 import { useDispatch, useSelector } from 'react-redux';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
 import Container from '../../atom/Container';
 import { Title } from '../Curation/Curation.styled';
 
@@ -84,19 +81,9 @@ const My = () => {
                 setUrl(response.data.data);
             })
             .catch(async (err) => {
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
             });
-    }, [token]);
+    }, []);
 
     useEffect(() => {
         setPageNum(pdfRef?._pdfInfo.numPages);

--- a/frontend/src/components/pages/Question/Question.jsx
+++ b/frontend/src/components/pages/Question/Question.jsx
@@ -4,8 +4,6 @@ import { useEffect } from 'react';
 import { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
 import Button from '../../atom/Button';
 import { Name } from '../../atom/Card/styled';
 import Container from '../../atom/Container';
@@ -34,20 +32,10 @@ const Question = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
             });
-    }, [token]);
+    }, []);
 
     return (
         <Container>

--- a/frontend/src/components/pages/QuestionDetail/QuestionDetail.jsx
+++ b/frontend/src/components/pages/QuestionDetail/QuestionDetail.jsx
@@ -24,12 +24,9 @@ import {
 import { Button } from '../QuestionForm/QuestionForm.style';
 import modify from '../../../assets/modifyImg.png';
 import deleteImg from '../../../assets/deleteImg.png';
-import { useDispatch, useSelector } from 'react-redux';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
+import { useSelector } from 'react-redux';
 
 const QuestionDetail = () => {
-    const dispatch = useDispatch();
     const [title, setTitle] = useState('');
     const [content, setContent] = useState('');
     const [answerData, setAnswerData] = useState([]);
@@ -65,17 +62,7 @@ const QuestionDetail = () => {
                     navigate('/question');
                     return;
                 }
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
             });
     }, [isPosted]);
@@ -101,17 +88,7 @@ const QuestionDetail = () => {
                         return;
                     }
                     console.log(err);
-                    if (err.response.status === 401) {
-                        const { exp, token } = await handleExpired();
-                        dispatch(
-                            authActions.login({
-                                token: token.data.access,
-                                exp,
-                            })
-                        );
-                    } else {
-                        alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                    }
+                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                     setLoading(false);
                 });
         }
@@ -131,20 +108,9 @@ const QuestionDetail = () => {
                 navigate('/question');
             } catch (error) {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                    setLoading(false);
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                    setLoading(false);
-                    return;
-                }
+
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
+                setLoading(false);
             }
         }
     };
@@ -179,17 +145,6 @@ const QuestionDetail = () => {
                         }
                     );
                 } catch (error) {
-                    if (err.response.status === 401) {
-                        const { exp, token } = await handleExpired();
-                        dispatch(
-                            authActions.login({
-                                token: token.data.access,
-                                exp,
-                            })
-                        );
-                    } else {
-                        alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                    }
                     alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 }
                 setLoading(false);

--- a/frontend/src/components/pages/QuestionForm/QuestionForm.jsx
+++ b/frontend/src/components/pages/QuestionForm/QuestionForm.jsx
@@ -3,8 +3,6 @@ import axios from 'axios';
 import { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useLocation, useNavigate } from 'react-router-dom';
-import handleExpired from '../../../helpers/handleExpired';
-import { authActions } from '../../../store/auth-slice';
 import { Name } from '../../atom/Card/styled';
 
 import Container from '../../atom/Container';
@@ -74,19 +72,7 @@ const QuestionForm = () => {
                         );
                     } catch (err) {
                         console.log(err);
-                        if (err.response.status === 401) {
-                            const { exp, token } = await handleExpired();
-                            dispatch(
-                                authActions.login({
-                                    token: token.data.access,
-                                    exp,
-                                })
-                            );
-                        } else {
-                            alert(
-                                '오류가 발생했습니다. 담당자에게 문의해주세요!'
-                            );
-                        }
+                        alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                         setLoading(false);
                     }
                 }

--- a/frontend/src/components/pages/Record/index.jsx
+++ b/frontend/src/components/pages/Record/index.jsx
@@ -1,6 +1,6 @@
 import Container from '../../atom/Container';
 import { Contents } from '../Home/styled';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 
 import morning from '../../../assets/morning.png';
 import mid from '../../../assets/lunch.png';
@@ -9,23 +9,14 @@ import cake from '../../../assets/cake.png';
 import drug from '../../../assets/drug.png';
 import water from '../../../assets/water.png';
 import today from '../../../assets/today.png';
-import jwt_decode from 'jwt-decode';
 
 import { DiaryTitle } from './styled';
 import { Icon, Name } from '../../atom/Card/styled';
-import { useCallback, useEffect, useState } from 'react';
-import axios from 'axios';
 import React from 'react';
-import imageCompression from 'browser-image-compression';
 import Water from '../Water';
 import Today from '../Today';
-import { useDispatch, useSelector } from 'react-redux';
-import useActions from '../../../hooks/useActions';
-import { postActions } from '../../../store/meal-slice/post-slice';
-import { authActions } from '../../../store/auth-slice';
 import Supplement from '../Supplement';
 import Meal from '../Meal';
-import { handleExpired } from '../../../helpers/handleExpired';
 
 function Record() {
     const param = useParams();

--- a/frontend/src/components/pages/Supplement/Supplement.jsx
+++ b/frontend/src/components/pages/Supplement/Supplement.jsx
@@ -2,12 +2,9 @@ import axios from 'axios';
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useParams } from 'react-router-dom';
-import jwt_decode from 'jwt-decode';
-import { authActions } from '../../../store/auth-slice';
 import { CircularProgress } from '@mui/material';
 import { supplementActions } from '../../../store/supplement-slice';
 import ImageCard from '../../molecules/ImageCard';
-import handleExpired from '../../../helpers/handleExpired';
 
 let initial = true;
 const Supplement = () => {
@@ -65,17 +62,8 @@ const Supplement = () => {
             setLoading(false);
         } catch (err) {
             console.log(err);
-            if (err.response.status === 401) {
-                const { exp, token } = await handleExpired();
-                dispatch(
-                    authActions.login({
-                        token: token.data.access,
-                        exp,
-                    })
-                );
-            } else {
-                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-            }
+
+            alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
             setIsRequestSent(false);
             setLoading(false);
         }
@@ -108,17 +96,7 @@ const Supplement = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
             });
     }, [isRequestSent, dispatch]);
@@ -127,7 +105,15 @@ const Supplement = () => {
         <CircularProgress />
     ) : (
         <>
-            <button onClick={addSupplement} style={{ marginBottom: 20 , border: 'none', borderRadius: '20px', padding: '5px 35px'}}>
+            <button
+                onClick={addSupplement}
+                style={{
+                    marginBottom: 20,
+                    border: 'none',
+                    borderRadius: '20px',
+                    padding: '5px 35px',
+                }}
+            >
                 추가하기
             </button>
 
@@ -163,7 +149,14 @@ const Supplement = () => {
                 <button
                     // 영양제 저장하는 버튼이었음
                     onClick={() => saveSupplement()}
-                    style={{ marginBottom: '30px', background: '#8A8A8E', border:'none', borderRadius: '20px', padding: '5px 35px', color: 'white'  }}
+                    style={{
+                        marginBottom: '30px',
+                        background: '#8A8A8E',
+                        border: 'none',
+                        borderRadius: '20px',
+                        padding: '5px 35px',
+                        color: 'white',
+                    }}
                 >
                     저장
                 </button>

--- a/frontend/src/components/pages/Today/Today.jsx
+++ b/frontend/src/components/pages/Today/Today.jsx
@@ -14,8 +14,6 @@ import {
     SummaryTitle,
     VerticalImageBox,
 } from './Today.style';
-import { authActions } from '../../../store/auth-slice';
-import handleExpired from '../../../helpers/handleExpired';
 
 const Today = ({ date }) => {
     const token = useSelector((state) => state.auth.token);
@@ -99,17 +97,8 @@ const Today = ({ date }) => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
             });
     }, [username, date]);

--- a/frontend/src/components/pages/Water/Water.jsx
+++ b/frontend/src/components/pages/Water/Water.jsx
@@ -7,10 +7,6 @@ import { useParams } from 'react-router-dom';
 import { CircularProgress } from '@mui/material';
 import { useDispatch, useSelector } from 'react-redux';
 import useActions from '../../../hooks/useActions';
-import jwt_decode from 'jwt-decode';
-import { authActions } from '../../../store/auth-slice';
-import handleExpired from '../../../helpers/handleExpired';
-import { waterActions } from '../../../store/water-slice';
 
 const Water = () => {
     const params = useParams();
@@ -63,20 +59,11 @@ const Water = () => {
             })
             .catch(async (err) => {
                 console.log(err);
-                if (err.response.status === 401) {
-                    const { exp, token } = await handleExpired();
-                    dispatch(
-                        authActions.login({
-                            token: token.data.access,
-                            exp,
-                        })
-                    );
-                } else {
-                    alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-                }
+
+                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
                 setLoading(false);
             });
-    }, [dispatch, token]);
+    }, [dispatch]);
 
     useEffect(() => {
         if (count >= currentAmount) {
@@ -118,17 +105,7 @@ const Water = () => {
             alert('수분 입력이 완료되었습니다!');
             setLoading(false);
         } catch (err) {
-            if (err.response.status === 401) {
-                const { exp, token } = await handleExpired();
-                dispatch(
-                    authActions.login({
-                        token: token.data.access,
-                        exp,
-                    })
-                );
-            } else {
-                alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
-            }
+            alert('오류가 발생했습니다. 담당자에게 문의해주세요!');
             setLoading(false);
         }
     };
@@ -179,7 +156,11 @@ const Water = () => {
                 }}
             >
                 <button
-                    style={{ border:'none', borderRadius: '20px', padding: '5px 35px'}}
+                    style={{
+                        border: 'none',
+                        borderRadius: '20px',
+                        padding: '5px 35px',
+                    }}
                     onClick={() => plusWater(250)}
                 >
                     250ml
@@ -198,7 +179,13 @@ const Water = () => {
                 ) : (
                     <button
                         onClick={() => sendWaterRequest()}
-                        style={{ background: '#8A8A8E', border:'none', borderRadius: '20px', padding: '5px 35px', color: 'white' }}
+                        style={{
+                            background: '#8A8A8E',
+                            border: 'none',
+                            borderRadius: '20px',
+                            padding: '5px 35px',
+                            color: 'white',
+                        }}
                     >
                         저장
                     </button>

--- a/frontend/src/recoil/token/token.js
+++ b/frontend/src/recoil/token/token.js
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const token = atom({
-    key: 'token',
-    default: null,
-});

--- a/frontend/src/store/auth-slice/index.js
+++ b/frontend/src/store/auth-slice/index.js
@@ -12,7 +12,7 @@ const authSlice = createSlice({
         login(state, action) {
             state.isLoggedIn = true;
             state.token = action.payload.token;
-            state.expiration_time = action.payload.expiration_time;
+            state.expiration_time = action.payload.exp;
         },
         logout(state) {
             state.isLoggedIn = false;


### PR DESCRIPTION
1. 이전에는 액세스토큰 만료 여부 확인하는 시점이 API요청이었음
2. 액세트토큰을 헤더에 담은 후 요청을 보냈을때 만료 여부를 반환받지 않고, App 컴포넌트에서 setTimeout을 통해 토큰 발급마다 자동으로 다음 발급 시점을 설정
3. 토큰 관리를 App 컴포넌트로 통합하고 나머지 컴포넌트에서의 추가 연장 로직은 모두 삭제